### PR TITLE
Fixes build in devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -24,7 +24,7 @@
         "gruntfuggly.todo-tree"
       ],
       "settings": {
-        "cmake.sourceDirectory": "${workspaceFolder}/src",
+        "cmake.sourceDirectory": "${workspaceFolder}",
         "cmake.buildDirectory": "${workspaceFolder}/build",
         "cmake.configureOnOpen": false,
         "cmake.generator": "Ninja",

--- a/.devcontainer/docker-compose.devcontainer.yml
+++ b/.devcontainer/docker-compose.devcontainer.yml
@@ -1,6 +1,7 @@
 services:
   embedded-cpp-dev:
     image: embedded-cpp-docker:devcontainer
+    user: "1000:1000"
     build:
       args:
         INSTALL_DEV_TOOLS: "true"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         run: docker compose build embedded-cpp-dev
 
       - name: Run host-debug workflow
-        run: docker compose run --rm host-debug
+        run: docker compose run --rm --user root host-debug
 
       - name: Upload test results
         if: always()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,9 +4,9 @@ services:
       context: .
       dockerfile: Dockerfile
     image: embedded-cpp-docker:latest
+    user: "${UID:-1000}:${GID:-1000}"
     volumes:
-      - .:/home/vscode/workspace:cached
-      - build-cache:/home/vscode/workspace/build
+      - .:/home/vscode/workspace
     working_dir: /home/vscode/workspace
 
   host-debug:
@@ -17,6 +17,4 @@ services:
     extends: embedded-cpp-dev
     command: /bin/bash -c "cmake --workflow --preset host-release"
 
-volumes:
-  build-cache:
 


### PR DESCRIPTION
Addresses two issues:
- devcontainer was pointing to the wrong sourceDirectory, so CMake Tools were not finding CMakePresets.json
- docker compose volume was always getting created as root, so building in the devcontainer would run into permissions issues