### PR TITLE
Enables static analysis for source and test code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -336,6 +336,11 @@ Managed via CMake `FetchContent`:
 
 **Warnings as Errors**: All enabled checks produce errors, not warnings.
 
+**Build Integration**: clang-tidy runs automatically during compilation for all source files (except tests and external dependencies). Build will fail if any violations are detected. No separate step required - just build normally:
+```bash
+cmake --build --preset=host --config Debug
+```
+
 ### Naming Conventions
 
 Enforced by `clang-tidy`:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,8 +113,6 @@ endif()
 
 clang_tidy("-header-filter=${CMAKE_CURRENT_SOURCE_DIR}/src/.*}")
 add_subdirectory(src)
-reset_clang_tidy()
-clang_tidy("-header-filter=${CMAKE_CURRENT_SOURCE_DIR}/src/.*}")
 add_subdirectory(test)
 reset_clang_tidy()
-add_subdirectory(py)
+add_subdirectory(py)   # No clang-tidy for python

--- a/PROJECT_PLAN.md
+++ b/PROJECT_PLAN.md
@@ -62,8 +62,8 @@ Explore modern C++ (C++23) and software engineering practices in embedded system
 - [x] DevContainer for VS Code
 - [x] CI/CD pipeline
 - [x] Comprehensive documentation
-- [ ] Code coverage reporting
-- [ ] Add static analysis build workflow (local and CI)
+- [x] Code coverage reporting
+- [x] Add static analysis through clang-tidy by default
 - [ ] Add UART abstraction
 - [ ] Add I2C abstraction
 - [ ] Add SPI abstraction


### PR DESCRIPTION
Uses clang-tidy and enabled by default