### PR TITLE
Use C++ uniform initialization throughout codebase

### DIFF
--- a/src/apps/uart_echo/uart_echo.cpp
+++ b/src/apps/uart_echo/uart_echo.cpp
@@ -60,7 +60,7 @@ auto UartEcho::Init() -> std::expected<void, common::Error> {
 
 auto UartEcho::Run() -> std::expected<void, common::Error> {
   // Send initial greeting message
-  const std::string greeting = "UART Echo ready! Send data to echo it back.\n";
+  const std::string greeting{"UART Echo ready! Send data to echo it back.\n"};
   auto send_result = board_.Uart1().Send(
       std::vector<uint8_t>(greeting.begin(), greeting.end()));
   if (!send_result) {

--- a/src/libs/mcu/host/host_emulator_messages.hpp
+++ b/src/libs/mcu/host/host_emulator_messages.hpp
@@ -15,8 +15,8 @@ enum class OperationType { kSet = 1, kGet, kSend, kReceive };
 enum class ObjectType { kPin = 1, kUart };
 
 struct PinEmulatorRequest {
-  MessageType type = MessageType::kRequest;
-  ObjectType object = ObjectType::kPin;
+  MessageType type{MessageType::kRequest};
+  ObjectType object{ObjectType::kPin};
   std::string name;
   OperationType operation;
   PinState state;
@@ -27,8 +27,8 @@ struct PinEmulatorRequest {
 };
 
 struct PinEmulatorResponse {
-  MessageType type = MessageType::kResponse;
-  ObjectType object = ObjectType::kPin;
+  MessageType type{MessageType::kResponse};
+  ObjectType object{ObjectType::kPin};
   std::string name;
   PinState state;
   common::Error status;
@@ -39,8 +39,8 @@ struct PinEmulatorResponse {
 };
 
 struct UartEmulatorRequest {
-  MessageType type = MessageType::kRequest;
-  ObjectType object = ObjectType::kUart;
+  MessageType type{MessageType::kRequest};
+  ObjectType object{ObjectType::kUart};
   std::string name;
   OperationType operation;
   std::vector<uint8_t> data;  // For Send operation
@@ -54,8 +54,8 @@ struct UartEmulatorRequest {
 };
 
 struct UartEmulatorResponse {
-  MessageType type = MessageType::kResponse;
-  ObjectType object = ObjectType::kUart;
+  MessageType type{MessageType::kResponse};
+  ObjectType object{ObjectType::kUart};
   std::string name;
   std::vector<uint8_t> data;  // Received data
   size_t bytes_transferred{0};

--- a/src/libs/mcu/host/host_i2c.cpp
+++ b/src/libs/mcu/host/host_i2c.cpp
@@ -21,8 +21,8 @@ auto HostI2CController::SendData(uint16_t address,
 
 auto HostI2CController::ReceiveData(uint16_t address, size_t size)
     -> std::expected<std::span<uint8_t>, int> {
-  return std::span<uint8_t>(data_buffers_[address].data(),
-                            std::min(size, data_buffers_[address].size()));
+  return std::span<uint8_t>{data_buffers_[address].data(),
+                            std::min(size, data_buffers_[address].size())};
 }
 
 auto HostI2CController::SendDataInterrupt(

--- a/src/libs/mcu/host/host_uart.cpp
+++ b/src/libs/mcu/host/host_uart.cpp
@@ -101,7 +101,7 @@ auto HostUart::Receive(std::span<uint8_t> buffer, uint32_t timeout_ms)
   }
 
   // Copy received data to buffer
-  const size_t bytes_to_copy = std::min(buffer.size(), response.data.size());
+  const size_t bytes_to_copy{std::min(buffer.size(), response.data.size())};
   std::copy_n(response.data.begin(), bytes_to_copy, buffer.begin());
 
   return bytes_to_copy;
@@ -283,7 +283,7 @@ auto HostUart::Receive(const std::string_view& message)
       callback(std::unexpected(response.status));
     } else {
       // Copy received data to buffer (stored for the callback)
-      const size_t bytes_received = response.bytes_transferred;
+      const size_t bytes_received{response.bytes_transferred};
       receive_buffer_.resize(bytes_received);
       std::copy_n(response.data.begin(), bytes_received,
                   receive_buffer_.begin());

--- a/src/libs/mcu/host/test_dispatcher.cpp
+++ b/src/libs/mcu/host/test_dispatcher.cpp
@@ -48,7 +48,7 @@ class DispatcherTest : public ::testing::Test {
 TEST_F(DispatcherTest, DispatchMessage) {
   const std::string sent_message{"Hello"};
   SimpleReceiver receiver;
-  ReceiverMap receiver_map = {{AcceptAll, receiver}};
+  ReceiverMap receiver_map{{AcceptAll, receiver}};
   Dispatcher dispatcher{receiver_map};
   auto reply = dispatcher.Dispatch(sent_message);
   EXPECT_TRUE(reply.has_value());
@@ -59,7 +59,7 @@ TEST_F(DispatcherTest, DispatchMessage) {
 TEST_F(DispatcherTest, DispatchMessageReject) {
   const std::string sent_message{"Hello"};
   SimpleReceiver receiver;
-  ReceiverMap receiver_map = {{RejectAll, receiver}};
+  ReceiverMap receiver_map{{RejectAll, receiver}};
   Dispatcher dispatcher{receiver_map};
   auto reply = dispatcher.Dispatch(sent_message);
   EXPECT_FALSE(reply.has_value());
@@ -70,7 +70,7 @@ TEST_F(DispatcherTest, DispatchMessageMultipleReceivers) {
   const std::string sent_message{"Hello"};
   SimpleReceiver receiver1;
   SimpleReceiver receiver2;
-  ReceiverMap receiver_map = {{IsHello, receiver1}, {IsWorld, receiver2}};
+  ReceiverMap receiver_map{{IsHello, receiver1}, {IsWorld, receiver2}};
   Dispatcher dispatcher{receiver_map};
   auto reply = dispatcher.Dispatch(sent_message);
   EXPECT_TRUE(reply.has_value());
@@ -83,7 +83,7 @@ TEST_F(DispatcherTest, DispatchMessageMultipleReceiversSecond) {
   const std::string sent_message{"World"};
   SimpleReceiver receiver1;
   SimpleReceiver receiver2;
-  ReceiverMap receiver_map = {{IsHello, receiver1}, {IsWorld, receiver2}};
+  ReceiverMap receiver_map{{IsHello, receiver1}, {IsWorld, receiver2}};
   Dispatcher dispatcher{receiver_map};
   auto reply = dispatcher.Dispatch(sent_message);
   EXPECT_TRUE(reply.has_value());
@@ -95,7 +95,7 @@ TEST_F(DispatcherTest, DispatchMessageMultipleReceiversSecond) {
 TEST_F(DispatcherTest, DispatchMessageUnhandled) {
   const std::string sent_message{"Unhandled"};
   SimpleReceiver receiver;
-  ReceiverMap receiver_map = {{IsHello, receiver}};
+  ReceiverMap receiver_map{{IsHello, receiver}};
   Dispatcher dispatcher{receiver_map};
   auto reply = dispatcher.Dispatch(sent_message);
   EXPECT_FALSE(reply.has_value());

--- a/src/libs/mcu/host/test_zmq_transport.cpp
+++ b/src/libs/mcu/host/test_zmq_transport.cpp
@@ -12,8 +12,8 @@ namespace {
 class ZmqTransportTest : public ::testing::Test {
  protected:
   void SetUp() override {
-    server_thread_ = std::thread(&ZmqTransportTest::ServerThread, this,
-                                 "ipc:///tmp/device_emulator.ipc");
+    server_thread_ = std::thread{&ZmqTransportTest::ServerThread, this,
+                                 "ipc:///tmp/device_emulator.ipc"};
   }
 
   void TearDown() override {
@@ -48,7 +48,7 @@ class ZmqTransportTest : public ::testing::Test {
             .events = ZMQ_POLLIN,
             .revents = 0}}};
 
-      const int ret = zmq::poll(items.data(), 1, std::chrono::milliseconds{50});
+      const int ret{zmq::poll(items.data(), 1, std::chrono::milliseconds{50})};
 
       if (ret == 0) {
         // Timeout occurred, check the stop condition
@@ -56,7 +56,7 @@ class ZmqTransportTest : public ::testing::Test {
           break;
         }
       } else if (ret > 0) {
-        zmq::message_t request;
+        zmq::message_t request{};
         if (socket.recv(request, zmq::recv_flags::none)) {
           const std::string_view request_str{
               static_cast<const char*>(request.data()), request.size()};
@@ -96,7 +96,7 @@ TEST(ZmqTransport, ClientMessage) {
   zmq::socket_t socket{context, zmq::socket_type::pair};
   socket.connect("ipc:///tmp/emulator_device.ipc");
   socket.send(zmq::str_buffer("Hello"), zmq::send_flags::none);
-  zmq::message_t response;
+  zmq::message_t response{};
   ASSERT_GT(socket.recv(response, zmq::recv_flags::none), 0);
   const std::string_view response_str{static_cast<const char*>(response.data()),
                                       response.size()};

--- a/src/libs/mcu/host/zmq_transport.cpp
+++ b/src/libs/mcu/host/zmq_transport.cpp
@@ -20,7 +20,7 @@ ZmqTransport::ZmqTransport(const std::string& to_emulator,
   }
 
   server_thread_ =
-      std::thread(&ZmqTransport::ServerThread, this, from_emulator);
+      std::thread{&ZmqTransport::ServerThread, this, from_emulator};
 }
 
 ZmqTransport::~ZmqTransport() {
@@ -57,7 +57,7 @@ void ZmqTransport::ServerThread(const std::string& endpoint) {
           .events = ZMQ_POLLIN,
           .revents = 0}}};
 
-    const int ret = zmq::poll(items.data(), 1, std::chrono::milliseconds{50});
+    const int ret{zmq::poll(items.data(), 1, std::chrono::milliseconds{50})};
 
     if (ret == 0) {
       // Timeout occurred, check the stop condition
@@ -65,7 +65,7 @@ void ZmqTransport::ServerThread(const std::string& endpoint) {
         break;
       }
     } else if (ret > 0) {
-      zmq::message_t request;
+      zmq::message_t request{};
       if (socket.recv(request, zmq::recv_flags::none)) {
         std::cout << "Received: " << request.to_string() << '\n';
         const std::string_view request_str{
@@ -98,7 +98,7 @@ auto ZmqTransport::Send(std::string_view data)
 }
 
 auto ZmqTransport::Receive() -> std::expected<std::string, common::Error> {
-  zmq::message_t msg;
+  zmq::message_t msg{};
   if (to_emulator_socket_.recv(msg, zmq::recv_flags::none) != msg.size()) {
     return std::unexpected(common::Error::kOperationFailed);
   }


### PR DESCRIPTION
Apply C++ uniform initialization syntax throughout the codebase for improved consistency and type safety. Changes include:

## Implementation Files (.cpp)
- src/libs/mcu/host/zmq_transport.cpp:
  * std::thread initialization: () → {}
  * zmq::message_t initialization: empty → {}
  * Local variable declarations: = → {}

- src/libs/mcu/host/host_uart.cpp:
  * const size_t declarations: = → {}
  * Note: Kept () for vector iterator initialization (correct for ranges)

- src/libs/mcu/host/host_i2c.cpp:
  * std::span initialization: () → {}

- src/apps/uart_echo/uart_echo.cpp:
  * const std::string initialization: = → {}
  * Note: Kept () for vector iterator initialization

## Header Files (.hpp)
- src/libs/mcu/host/host_emulator_messages.hpp:
  * Default member initializers: = → {}
  * Affects MessageType and ObjectType fields in all emulator structs

## Test Files (.cpp)
- src/libs/mcu/host/test_zmq_transport.cpp:
  * std::thread initialization: () → {}
  * zmq::message_t declarations: empty → {}
  * Local int declarations: = → {}

- src/libs/mcu/host/test_dispatcher.cpp:
  * ReceiverMap initialization: = → direct {}

- src/libs/mcu/host/test_host_uart.cpp:
  * std::thread initialization: () → {}
  * Local variable declarations: = → {}
  * std::array initialization: = → {}
  * std::vector declarations: empty → {}
  * Function return value capture: = → {}

## Important Notes
Vector iterator initialization uses () rather than {} because:
- std::vector<T>(begin, end) constructs from range
- std::vector<T>{begin, end} would create vector of iterators This is correct C++ behavior and intentionally preserved.

All other initializations now use uniform initialization syntax for consistency with modern C++ best practices.