### PR TITLE
Evaluate C++ code for const correctness

### DIFF
--- a/src/apps/uart_echo/uart_echo.cpp
+++ b/src/apps/uart_echo/uart_echo.cpp
@@ -35,11 +35,11 @@ auto UartEcho::Init() -> std::expected<void, common::Error> {
         return board_.Uart1().SetRxHandler(
             [this](const uint8_t* data, size_t size) {
               // Echo the data back
-              std::vector<uint8_t> echo_data(data, data + size);
+              const std::vector<uint8_t> echo_data(data, data + size);
               std::ignore = board_.Uart1().Send(echo_data);
 
               // Toggle LED1 to indicate data received
-              auto led_state = board_.UserLed1().Get();
+              const auto led_state = board_.UserLed1().Get();
               if (led_state && led_state.value() == mcu::PinState::kHigh) {
                 std::ignore = board_.UserLed1().SetLow();
               } else {
@@ -62,7 +62,7 @@ auto UartEcho::Run() -> std::expected<void, common::Error> {
   // The actual echo happens via the RxHandler callback
   while (true) {
     mcu::Delay(1000ms);
-    auto led_state = board_.UserLed2().Get();
+    const auto led_state = board_.UserLed2().Get();
     if (!led_state) {
       return std::unexpected(led_state.error());
     }

--- a/src/libs/mcu/host/dispatcher.hpp
+++ b/src/libs/mcu/host/dispatcher.hpp
@@ -24,7 +24,7 @@ class Dispatcher {
   auto operator=(const Dispatcher&) -> Dispatcher& = delete;
   auto operator=(Dispatcher&&) -> Dispatcher& = delete;
 
-  auto Dispatch(const std::string_view& message)
+  auto Dispatch(const std::string_view& message) const
       -> std::expected<std::string, common::Error> {
     for (const auto& [predicate, receiver] : receivers_) {
       if (predicate(message)) {

--- a/src/libs/mcu/host/host_uart.cpp
+++ b/src/libs/mcu/host/host_uart.cpp
@@ -173,9 +173,9 @@ auto HostUart::ReceiveAsync(
   return {};
 }
 
-auto HostUart::IsBusy() -> bool { return busy_; }
+auto HostUart::IsBusy() const -> bool { return busy_; }
 
-auto HostUart::Available() -> size_t {
+auto HostUart::Available() const -> size_t {
   // For host implementation, we don't maintain a receive buffer
   // Always return 0 (data is retrieved on-demand from emulator)
   return 0;

--- a/src/libs/mcu/host/host_uart.hpp
+++ b/src/libs/mcu/host/host_uart.hpp
@@ -40,8 +40,8 @@ class HostUart final : public Uart, public Receiver {
       std::function<void(std::expected<size_t, common::Error>)> callback)
       -> std::expected<void, common::Error> override;
 
-  auto IsBusy() -> bool override;
-  auto Available() -> size_t override;
+  auto IsBusy() const -> bool override;
+  auto Available() const -> size_t override;
   auto Flush() -> std::expected<void, common::Error> override;
 
   auto SetRxHandler(std::function<void(const uint8_t*, size_t)> handler)

--- a/src/libs/mcu/host/test_dispatcher.cpp
+++ b/src/libs/mcu/host/test_dispatcher.cpp
@@ -49,7 +49,7 @@ TEST_F(DispatcherTest, DispatchMessage) {
   const std::string sent_message{"Hello"};
   SimpleReceiver receiver;
   ReceiverMap receiver_map{{AcceptAll, receiver}};
-  Dispatcher dispatcher{receiver_map};
+  const Dispatcher dispatcher{receiver_map};
   auto reply = dispatcher.Dispatch(sent_message);
   EXPECT_TRUE(reply.has_value());
   EXPECT_EQ(reply.value(), "Received message");
@@ -60,7 +60,7 @@ TEST_F(DispatcherTest, DispatchMessageReject) {
   const std::string sent_message{"Hello"};
   SimpleReceiver receiver;
   ReceiverMap receiver_map{{RejectAll, receiver}};
-  Dispatcher dispatcher{receiver_map};
+  const Dispatcher dispatcher{receiver_map};
   auto reply = dispatcher.Dispatch(sent_message);
   EXPECT_FALSE(reply.has_value());
   EXPECT_EQ(receiver.received_message, "");
@@ -71,7 +71,7 @@ TEST_F(DispatcherTest, DispatchMessageMultipleReceivers) {
   SimpleReceiver receiver1;
   SimpleReceiver receiver2;
   ReceiverMap receiver_map{{IsHello, receiver1}, {IsWorld, receiver2}};
-  Dispatcher dispatcher{receiver_map};
+  const Dispatcher dispatcher{receiver_map};
   auto reply = dispatcher.Dispatch(sent_message);
   EXPECT_TRUE(reply.has_value());
   EXPECT_EQ(reply.value(), "Received message");
@@ -84,7 +84,7 @@ TEST_F(DispatcherTest, DispatchMessageMultipleReceiversSecond) {
   SimpleReceiver receiver1;
   SimpleReceiver receiver2;
   ReceiverMap receiver_map{{IsHello, receiver1}, {IsWorld, receiver2}};
-  Dispatcher dispatcher{receiver_map};
+  const Dispatcher dispatcher{receiver_map};
   auto reply = dispatcher.Dispatch(sent_message);
   EXPECT_TRUE(reply.has_value());
   EXPECT_EQ(reply.value(), "Received message");
@@ -96,7 +96,7 @@ TEST_F(DispatcherTest, DispatchMessageUnhandled) {
   const std::string sent_message{"Unhandled"};
   SimpleReceiver receiver;
   ReceiverMap receiver_map{{IsHello, receiver}};
-  Dispatcher dispatcher{receiver_map};
+  const Dispatcher dispatcher{receiver_map};
   auto reply = dispatcher.Dispatch(sent_message);
   EXPECT_FALSE(reply.has_value());
   EXPECT_EQ(receiver.received_message, "");

--- a/src/libs/mcu/uart.hpp
+++ b/src/libs/mcu/uart.hpp
@@ -84,11 +84,11 @@ class Uart {
 
   /// @brief Check if UART is busy transmitting
   /// @return True if busy, false otherwise
-  virtual auto IsBusy() -> bool = 0;
+  virtual auto IsBusy() const -> bool = 0;
 
   /// @brief Get number of bytes available to read
   /// @return Number of bytes in receive buffer
-  virtual auto Available() -> size_t = 0;
+  virtual auto Available() const -> size_t = 0;
 
   /// @brief Flush transmit buffer (wait for all data to be sent)
   /// @return Success or error code


### PR DESCRIPTION
This commit adds const qualifiers to methods and variables that don't modify state, improving type safety and enabling better compiler optimizations.

Changes:
- Add const to Uart::IsBusy() and Uart::Available() interface methods
- Add const to HostUart::IsBusy() and HostUart::Available() overrides
- Add const to Dispatcher::Dispatch() method (only reads receivers)
- Add const to local variables in uart_echo.cpp (echo_data, led_state)

These changes maintain the same functionality while making the code more correct and enabling use of these methods on const objects.