### PR TITLE
Refactor I2C and UART interfaces to use std::byte

### DIFF
--- a/src/apps/i2c_demo/i2c_demo.cpp
+++ b/src/apps/i2c_demo/i2c_demo.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <array>
 #include <chrono>
+#include <cstddef>
 #include <expected>
 
 #include "apps/app.hpp"
@@ -35,7 +36,8 @@ auto I2CDemo::Run() -> std::expected<void, common::Error> {
   constexpr uint16_t kDeviceAddress{0x50};
 
   // Test pattern to write/read
-  const std::array<uint8_t, 4> test_pattern{0xDE, 0xAD, 0xBE, 0xEF};
+  const std::array<std::byte, 4> test_pattern{std::byte{0xDE}, std::byte{0xAD},
+                                              std::byte{0xBE}, std::byte{0xEF}};
 
   // Main loop - write pattern, read it back, verify
   while (true) {

--- a/src/apps/uart_echo/uart_echo.cpp
+++ b/src/apps/uart_echo/uart_echo.cpp
@@ -33,9 +33,9 @@ auto UartEcho::Init() -> std::expected<void, common::Error> {
           [this, &uart_config]() { return board_.Uart1().Init(uart_config); })
       .and_then([this]() {
         return board_.Uart1().SetRxHandler(
-            [this](const uint8_t* data, size_t size) {
+            [this](const std::byte* data, size_t size) {
               // Echo the data back
-              const std::vector<uint8_t> echo_data(data, data + size);
+              const std::vector<std::byte> echo_data(data, data + size);
               std::ignore = board_.Uart1().Send(echo_data);
 
               // Toggle LED1 to indicate data received
@@ -47,8 +47,10 @@ auto UartEcho::Init() -> std::expected<void, common::Error> {
 auto UartEcho::Run() -> std::expected<void, common::Error> {
   // Send initial greeting message
   const std::string greeting{"UART Echo ready! Send data to echo it back.\n"};
+  const auto* greeting_bytes{
+      reinterpret_cast<const std::byte*>(greeting.data())};
   auto send_result{board_.Uart1().Send(
-      std::vector<uint8_t>(greeting.begin(), greeting.end()))};
+      std::span<const std::byte>{greeting_bytes, greeting.size()})};
   if (!send_result) {
     return std::unexpected(send_result.error());
   }

--- a/src/libs/mcu/host/emulator_message_json_encoder.hpp
+++ b/src/libs/mcu/host/emulator_message_json_encoder.hpp
@@ -1,11 +1,27 @@
 #pragma once
 
+#include <cstddef>
 #include <nlohmann/json.hpp>
 #include <string>
+#include <vector>
 
 #include "libs/common/error.hpp"
 #include "libs/mcu/host/host_emulator_messages.hpp"
 #include "libs/mcu/pin.hpp"
+
+// Custom JSON serialization for std::byte
+namespace nlohmann {
+template <>
+struct adl_serializer<std::byte> {
+  static void to_json(json& j, const std::byte& b) {
+    j = std::to_integer<uint8_t>(b);
+  }
+
+  static void from_json(const json& j, std::byte& b) {
+    b = static_cast<std::byte>(j.get<uint8_t>());
+  }
+};
+}  // namespace nlohmann
 
 namespace common {
 

--- a/src/libs/mcu/host/host_emulator_messages.hpp
+++ b/src/libs/mcu/host/host_emulator_messages.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
 #include <expected>
 #include <string>
@@ -43,9 +44,9 @@ struct UartEmulatorRequest {
   ObjectType object{ObjectType::kUart};
   std::string name;
   OperationType operation;
-  std::vector<uint8_t> data;  // For Send operation
-  size_t size{0};             // For Receive operation (buffer size)
-  uint32_t timeout_ms{0};     // For Receive operation
+  std::vector<std::byte> data;  // For Send operation
+  size_t size{0};               // For Receive operation (buffer size)
+  uint32_t timeout_ms{0};       // For Receive operation
   auto operator==(const UartEmulatorRequest& other) const -> bool {
     return type == other.type && object == other.object && name == other.name &&
            operation == other.operation && data == other.data &&
@@ -57,7 +58,7 @@ struct UartEmulatorResponse {
   MessageType type{MessageType::kResponse};
   ObjectType object{ObjectType::kUart};
   std::string name;
-  std::vector<uint8_t> data;  // Received data
+  std::vector<std::byte> data;  // Received data
   size_t bytes_transferred{0};
   common::Error status;
   auto operator==(const UartEmulatorResponse& other) const -> bool {
@@ -73,8 +74,8 @@ struct I2CEmulatorRequest {
   std::string name;
   OperationType operation;
   uint16_t address{0};
-  std::vector<uint8_t> data;  // For Send operation
-  size_t size{0};             // For Receive operation (buffer size)
+  std::vector<std::byte> data;  // For Send operation
+  size_t size{0};               // For Receive operation (buffer size)
   auto operator==(const I2CEmulatorRequest& other) const -> bool {
     return type == other.type && object == other.object && name == other.name &&
            operation == other.operation && address == other.address &&
@@ -87,7 +88,7 @@ struct I2CEmulatorResponse {
   ObjectType object{ObjectType::kI2C};
   std::string name;
   uint16_t address{0};
-  std::vector<uint8_t> data;  // Received data
+  std::vector<std::byte> data;  // Received data
   size_t bytes_transferred{0};
   common::Error status;
   auto operator==(const I2CEmulatorResponse& other) const -> bool {

--- a/src/libs/mcu/host/host_i2c.cpp
+++ b/src/libs/mcu/host/host_i2c.cpp
@@ -15,7 +15,7 @@
 namespace mcu {
 
 auto HostI2CController::SendData(uint16_t address,
-                                 std::span<const uint8_t> data)
+                                 std::span<const std::byte> data)
     -> std::expected<void, common::Error> {
   const I2CEmulatorRequest request{
       .type = MessageType::kRequest,
@@ -23,7 +23,7 @@ auto HostI2CController::SendData(uint16_t address,
       .name = name_,
       .operation = OperationType::kSend,
       .address = address,
-      .data = std::vector<uint8_t>(data.begin(), data.end()),
+      .data = std::vector<std::byte>(data.begin(), data.end()),
       .size = 0,
   };
 
@@ -46,7 +46,7 @@ auto HostI2CController::SendData(uint16_t address,
 }
 
 auto HostI2CController::ReceiveData(uint16_t address, size_t size)
-    -> std::expected<std::span<uint8_t>, common::Error> {
+    -> std::expected<std::span<std::byte>, common::Error> {
   const I2CEmulatorRequest request{
       .type = MessageType::kRequest,
       .object = ObjectType::kI2C,
@@ -77,11 +77,11 @@ auto HostI2CController::ReceiveData(uint16_t address, size_t size)
   const size_t bytes_to_copy{std::min(response.data.size(), buffer.size())};
   std::copy_n(response.data.begin(), bytes_to_copy, buffer.begin());
 
-  return std::span<uint8_t>{buffer.data(), bytes_to_copy};
+  return std::span<std::byte>{buffer.data(), bytes_to_copy};
 }
 
 auto HostI2CController::SendDataInterrupt(
-    uint16_t address, std::span<const uint8_t> data,
+    uint16_t address, std::span<const std::byte> data,
     std::function<void(std::expected<void, common::Error>)> callback)
     -> std::expected<void, common::Error> {
   callback(SendData(address, data));
@@ -90,14 +90,14 @@ auto HostI2CController::SendDataInterrupt(
 
 auto HostI2CController::ReceiveDataInterrupt(
     uint16_t address, size_t size,
-    std::function<void(std::expected<std::span<uint8_t>, common::Error>)>
+    std::function<void(std::expected<std::span<std::byte>, common::Error>)>
         callback) -> std::expected<void, common::Error> {
   callback(ReceiveData(address, size));
   return {};
 }
 
 auto HostI2CController::SendDataDma(
-    uint16_t address, std::span<const uint8_t> data,
+    uint16_t address, std::span<const std::byte> data,
     std::function<void(std::expected<void, common::Error>)> callback)
     -> std::expected<void, common::Error> {
   callback(SendData(address, data));
@@ -106,7 +106,7 @@ auto HostI2CController::SendDataDma(
 
 auto HostI2CController::ReceiveDataDma(
     uint16_t address, size_t size,
-    std::function<void(std::expected<std::span<uint8_t>, common::Error>)>
+    std::function<void(std::expected<std::span<std::byte>, common::Error>)>
         callback) -> std::expected<void, common::Error> {
   callback(ReceiveData(address, size));
   return {};

--- a/src/libs/mcu/host/host_i2c.hpp
+++ b/src/libs/mcu/host/host_i2c.hpp
@@ -23,27 +23,27 @@ class HostI2CController final : public I2CController, public Receiver {
   auto operator=(HostI2CController&&) -> HostI2CController& = delete;
   ~HostI2CController() override = default;
 
-  auto SendData(uint16_t address, std::span<const uint8_t> data)
+  auto SendData(uint16_t address, std::span<const std::byte> data)
       -> std::expected<void, common::Error> override;
 
   auto ReceiveData(uint16_t address, size_t size)
-      -> std::expected<std::span<uint8_t>, common::Error> override;
+      -> std::expected<std::span<std::byte>, common::Error> override;
 
   auto SendDataInterrupt(
-      uint16_t address, std::span<const uint8_t> data,
+      uint16_t address, std::span<const std::byte> data,
       std::function<void(std::expected<void, common::Error>)> callback)
       -> std::expected<void, common::Error> override;
   auto ReceiveDataInterrupt(
       uint16_t address, size_t size,
-      std::function<void(std::expected<std::span<uint8_t>, common::Error>)>
+      std::function<void(std::expected<std::span<std::byte>, common::Error>)>
           callback) -> std::expected<void, common::Error> override;
 
-  auto SendDataDma(uint16_t address, std::span<const uint8_t> data,
+  auto SendDataDma(uint16_t address, std::span<const std::byte> data,
                    std::function<void(std::expected<void, common::Error>)>
                        callback) -> std::expected<void, common::Error> override;
   auto ReceiveDataDma(
       uint16_t address, size_t size,
-      std::function<void(std::expected<std::span<uint8_t>, common::Error>)>
+      std::function<void(std::expected<std::span<std::byte>, common::Error>)>
           callback) -> std::expected<void, common::Error> override;
   auto Receive(const std::string_view& message)
       -> std::expected<std::string, common::Error> override;
@@ -51,6 +51,6 @@ class HostI2CController final : public I2CController, public Receiver {
  private:
   const std::string name_;
   Transport& transport_;
-  std::unordered_map<uint16_t, std::array<uint8_t, 256>> data_buffers_;
+  std::unordered_map<uint16_t, std::array<std::byte, 256>> data_buffers_;
 };
 }  // namespace mcu

--- a/src/libs/mcu/host/host_uart.cpp
+++ b/src/libs/mcu/host/host_uart.cpp
@@ -27,7 +27,7 @@ auto HostUart::Init(const UartConfig& config)
   return {};
 }
 
-auto HostUart::Send(std::span<const uint8_t> data)
+auto HostUart::Send(std::span<const std::byte> data)
     -> std::expected<void, common::Error> {
   if (!initialized_) {
     return std::unexpected(common::Error::kInvalidState);
@@ -42,7 +42,7 @@ auto HostUart::Send(std::span<const uint8_t> data)
       .object = ObjectType::kUart,
       .name = name_,
       .operation = OperationType::kSend,
-      .data = std::vector<uint8_t>(data.begin(), data.end()),
+      .data = std::vector<std::byte>(data.begin(), data.end()),
       .size = 0,
       .timeout_ms = 0,
   };
@@ -59,7 +59,7 @@ auto HostUart::Send(std::span<const uint8_t> data)
       });
 }
 
-auto HostUart::Receive(std::span<uint8_t> buffer, uint32_t timeout_ms)
+auto HostUart::Receive(std::span<std::byte> buffer, uint32_t timeout_ms)
     -> std::expected<size_t, common::Error> {
   if (!initialized_) {
     return std::unexpected(common::Error::kInvalidState);
@@ -99,7 +99,7 @@ auto HostUart::Receive(std::span<uint8_t> buffer, uint32_t timeout_ms)
       });
 }
 
-auto HostUart::SendAsync(std::span<const uint8_t> data,
+auto HostUart::SendAsync(std::span<const std::byte> data,
                          std::function<void(std::expected<void, common::Error>)>
                              callback) -> std::expected<void, common::Error> {
   if (!initialized_) {
@@ -118,7 +118,7 @@ auto HostUart::SendAsync(std::span<const uint8_t> data,
       .object = ObjectType::kUart,
       .name = name_,
       .operation = OperationType::kSend,
-      .data = std::vector<uint8_t>(data.begin(), data.end()),
+      .data = std::vector<std::byte>(data.begin(), data.end()),
       .size = 0,
       .timeout_ms = 0,
   };
@@ -135,7 +135,7 @@ auto HostUart::SendAsync(std::span<const uint8_t> data,
 }
 
 auto HostUart::ReceiveAsync(
-    std::span<uint8_t> buffer,
+    std::span<std::byte> buffer,
     std::function<void(std::expected<size_t, common::Error>)> callback)
     -> std::expected<void, common::Error> {
   if (!initialized_) {
@@ -191,8 +191,8 @@ auto HostUart::Flush() -> std::expected<void, common::Error> {
   return {};
 }
 
-auto HostUart::SetRxHandler(std::function<void(const uint8_t*, size_t)> handler)
-    -> std::expected<void, common::Error> {
+auto HostUart::SetRxHandler(std::function<void(const std::byte*, size_t)>
+                                handler) -> std::expected<void, common::Error> {
   if (!initialized_) {
     return std::unexpected(common::Error::kInvalidState);
   }

--- a/src/libs/mcu/host/host_uart.hpp
+++ b/src/libs/mcu/host/host_uart.hpp
@@ -25,18 +25,18 @@ class HostUart final : public Uart, public Receiver {
   auto Init(const UartConfig& config)
       -> std::expected<void, common::Error> override;
 
-  auto Send(std::span<const uint8_t> data)
+  auto Send(std::span<const std::byte> data)
       -> std::expected<void, common::Error> override;
 
-  auto Receive(std::span<uint8_t> buffer, uint32_t timeout_ms)
+  auto Receive(std::span<std::byte> buffer, uint32_t timeout_ms)
       -> std::expected<size_t, common::Error> override;
 
-  auto SendAsync(std::span<const uint8_t> data,
+  auto SendAsync(std::span<const std::byte> data,
                  std::function<void(std::expected<void, common::Error>)>
                      callback) -> std::expected<void, common::Error> override;
 
   auto ReceiveAsync(
-      std::span<uint8_t> buffer,
+      std::span<std::byte> buffer,
       std::function<void(std::expected<size_t, common::Error>)> callback)
       -> std::expected<void, common::Error> override;
 
@@ -44,7 +44,7 @@ class HostUart final : public Uart, public Receiver {
   auto Available() const -> size_t override;
   auto Flush() -> std::expected<void, common::Error> override;
 
-  auto SetRxHandler(std::function<void(const uint8_t*, size_t)> handler)
+  auto SetRxHandler(std::function<void(const std::byte*, size_t)> handler)
       -> std::expected<void, common::Error> override;
 
   // Receiver interface for handling async responses from emulator
@@ -63,10 +63,10 @@ class HostUart final : public Uart, public Receiver {
   std::function<void(std::expected<size_t, common::Error>)> receive_callback_{};
 
   // Receive handler for unsolicited incoming data
-  std::function<void(const uint8_t*, size_t)> rx_handler_{};
+  std::function<void(const std::byte*, size_t)> rx_handler_{};
 
   // Receive buffer for async operations
-  std::vector<uint8_t> receive_buffer_{};
+  std::vector<std::byte> receive_buffer_{};
 };
 
 }  // namespace mcu

--- a/src/libs/mcu/i2c.hpp
+++ b/src/libs/mcu/i2c.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
 #include <expected>
 #include <functional>
@@ -13,28 +14,28 @@ class I2CController {
  public:
   virtual ~I2CController() = default;
 
-  virtual auto SendData(uint16_t address, std::span<const uint8_t> data)
+  virtual auto SendData(uint16_t address, std::span<const std::byte> data)
       -> std::expected<void, common::Error> = 0;
 
   virtual auto ReceiveData(uint16_t address, size_t size)
-      -> std::expected<std::span<uint8_t>, common::Error> = 0;
+      -> std::expected<std::span<std::byte>, common::Error> = 0;
 
   virtual auto SendDataInterrupt(
-      uint16_t address, std::span<const uint8_t> data,
+      uint16_t address, std::span<const std::byte> data,
       std::function<void(std::expected<void, common::Error>)> callback)
       -> std::expected<void, common::Error> = 0;
   virtual auto ReceiveDataInterrupt(
       uint16_t address, size_t size,
-      std::function<void(std::expected<std::span<uint8_t>, common::Error>)>
+      std::function<void(std::expected<std::span<std::byte>, common::Error>)>
           callback) -> std::expected<void, common::Error> = 0;
 
   virtual auto SendDataDma(
-      uint16_t address, std::span<const uint8_t> data,
+      uint16_t address, std::span<const std::byte> data,
       std::function<void(std::expected<void, common::Error>)> callback)
       -> std::expected<void, common::Error> = 0;
   virtual auto ReceiveDataDma(
       uint16_t address, size_t size,
-      std::function<void(std::expected<std::span<uint8_t>, common::Error>)>
+      std::function<void(std::expected<std::span<std::byte>, common::Error>)>
           callback) -> std::expected<void, common::Error> = 0;
 };
 

--- a/src/libs/mcu/uart.hpp
+++ b/src/libs/mcu/uart.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
 #include <expected>
 #include <functional>
@@ -52,14 +53,14 @@ class Uart {
   /// @brief Send data (blocking)
   /// @param data Span of bytes to send
   /// @return Success or error code
-  virtual auto Send(std::span<const uint8_t> data)
+  virtual auto Send(std::span<const std::byte> data)
       -> std::expected<void, common::Error> = 0;
 
   /// @brief Receive data (blocking with timeout)
   /// @param buffer Buffer to store received data
   /// @param timeout_ms Timeout in milliseconds (0 = wait forever)
   /// @return Number of bytes received or error
-  virtual auto Receive(std::span<uint8_t> buffer, uint32_t timeout_ms = 0)
+  virtual auto Receive(std::span<std::byte> buffer, uint32_t timeout_ms = 0)
       -> std::expected<size_t, common::Error> = 0;
 
   /// @brief Send data asynchronously
@@ -68,7 +69,7 @@ class Uart {
   /// @param callback Called when transfer completes
   /// @return Success or error code
   virtual auto SendAsync(
-      std::span<const uint8_t> data,
+      std::span<const std::byte> data,
       std::function<void(std::expected<void, common::Error>)> callback)
       -> std::expected<void, common::Error> = 0;
 
@@ -78,7 +79,7 @@ class Uart {
   /// @param callback Called when data is received (with number of bytes)
   /// @return Success or error code
   virtual auto ReceiveAsync(
-      std::span<uint8_t> buffer,
+      std::span<std::byte> buffer,
       std::function<void(std::expected<size_t, common::Error>)> callback)
       -> std::expected<void, common::Error> = 0;
 
@@ -99,7 +100,8 @@ class Uart {
   /// application when data arrives asynchronously (e.g., from external source)
   /// @param handler Callback invoked when data arrives (data pointer and size)
   /// @return Success or error code
-  virtual auto SetRxHandler(std::function<void(const uint8_t*, size_t)> handler)
+  virtual auto SetRxHandler(
+      std::function<void(const std::byte*, size_t)> handler)
       -> std::expected<void, common::Error> = 0;
 };
 


### PR DESCRIPTION
Replace uint8_t with std::byte for all I2C and UART data transmission APIs to improve type safety and prevent accidental arithmetic operations on raw byte data. This change aligns with modern C++ best practices and makes the intent of byte-oriented operations more explicit throughout the codebase.

Updated interfaces, implementations, applications, and tests. Added custom JSON serialization support for std::byte in the host emulator message encoder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)