### PR TITLE
chore(devcontainer): add the GitHub CLI feature

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,6 +8,12 @@
   "workspaceFolder": "/home/vscode/workspace",
   "remoteUser": "vscode",
   "overrideCommand": true,
+  // Interactive conveniences only. Build/test tooling belongs in the Dockerfile
+  // so `docker compose run` and CI get it too; features apply to this
+  // devcontainer alone.
+  "features": {
+    "ghcr.io/devcontainers/features/github-cli:1": {}
+  },
   "customizations": {
     "vscode": {
       "extensions": [


### PR DESCRIPTION
gh is not in Ubuntu's default apt sources, so it had to be installed by hand in each new container. Add the devcontainer feature instead -- one line, and it tracks upstream releases.

Scoped to the devcontainer rather than the Dockerfile on purpose: gh is an interactive convenience, not a build dependency, so `docker compose run` and CI have no need for it.

Note that gh still needs `gh auth login` (or GH_TOKEN) per user; git itself pushes over SSH and shares no credentials with gh.