### PR TITLE
fix(arm): do not clear STOPF on the I2C NACK path

### DIFF
--- a/src/libs/mcu/arm_cm7/i2c.cpp
+++ b/src/libs/mcu/arm_cm7/i2c.cpp
@@ -75,7 +75,11 @@ auto EnablePeripheralClock(I2CId id) -> void {
   const std::uint32_t start = Millis();
   while ((registers->ISR & flag) == 0U) {
     if ((registers->ISR & I2C_ISR_NACKF) != 0U) {
-      registers->ICR = I2C_ICR_NACKCF | I2C_ICR_STOPCF;
+      // Clear only NACKF. Autoend generates the STOP itself in response to the
+      // NACK, and FinishTransfer is what waits for and clears the resulting
+      // STOPF -- clearing it here would leave that wait with nothing to
+      // observe, burning the whole transfer timeout on every failed transfer.
+      registers->ICR = I2C_ICR_NACKCF;
       return std::unexpected(common::Error::kOperationFailed);
     }
     if ((Millis() - start) > kTransferTimeoutMs) {


### PR DESCRIPTION
`WaitForFlag` cleared `NACKCF` and `STOPCF` together when it saw a NACK. But
autoend generates the STOP itself in response to that NACK, and
`FinishTransfer` is what waits for the resulting `STOPF` — so clearing it there
left that wait with nothing to observe, burning the full 25 ms transfer timeout
on every failed transfer.

Not a hang: the timeout bounds it, and the error the caller sees is the NACK's
`kOperationFailed` rather than the discarded `kTimeout`. But it made a missing
device cost 25 ms per attempt instead of the ~90 µs an address phase takes at
100 kHz.

## Verified on hardware, not just reasoned about

Flashed `i2c_demo` to the F767ZI with nothing on the bus and broke on both
failure branches of `WaitForFlag` to see which one the driver actually takes:

```
Breakpoint 1, mcu::(anonymous namespace)::WaitForFlag (registers=0x40005400, flag=2)
    at src/libs/mcu/arm_cm7/i2c.cpp:82
#0  WaitForFlag ... i2c.cpp:82          <- the NACK branch
#1  mcu::I2CBus::SendData (address=80)  ... i2c.cpp:167
#2  app::I2CDemo::Run                   ... i2c_demo.cpp:41
ISR now = 0x00000031  (NACKF=1)
```

`ISR = 0x31` is the whole argument for this change: TXE (bit 0), **NACKF
(bit 4) and STOPF (bit 5) are set at the same instant**. The STOP has already
happened by the time the NACK is detected — so the old code was clearing a flag
`FinishTransfer` was about to wait for, guaranteeing the timeout every time.

Incidentally this also confirms the I2C driver end to end on real silicon: the
address goes out at 0x50, nothing answers, the peripheral raises NACKF, and
`SendData` returns `kOperationFailed` without hanging.

## Checks

- Host: 32/32
- ARM: Debug and Release build clean, 6 images pass `tools/verify-firmware.sh`
- `tools/format.sh --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
